### PR TITLE
feat: warn active plan holders before deleting their account

### DIFF
--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -24,6 +24,7 @@ const AccountPage = () => {
   const [state, setState] = useState(State.Pure);
   const [removalInitiated, setRemovalInitiated] = useState(false);
   const isLargeScreen = useMedia(`(min-width: ${theme.screens.xl})`);
+  const hasActiveSubscription = user.tier > 1 && !user.subscriptionCancelAtPeriodEnd;
 
   const prompt = () => setRemovalInitiated(true);
   const abort = () => setRemovalInitiated(false);
@@ -82,6 +83,15 @@ const AccountPage = () => {
                 </HighlightedLink>{" "}
                 them to Skynet.
               </p>
+              {hasActiveSubscription && (
+                <Alert $variant="info" className="mt-4">
+                  Please make sure to{" "}
+                  <HighlightedLink as="a" href="/api/stripe/billing" target="_blank" rel="noreferrer">
+                    cancel your subscription in Stripe
+                  </HighlightedLink>{" "}
+                  prior to deleting your account.
+                </Alert>
+              )}
             </div>
             <button
               type="button"


### PR DESCRIPTION
Adds a warning in `Delete account` section, which reminds the users to cancel their subscription prior to deleting their account (if needed). This is just a temporary solution until SKY-717 is implemented.

## Visual changes
![image](https://user-images.githubusercontent.com/3853033/170978162-8aa4a491-c31f-4566-9be5-d64d36132e7a.png)

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
