### PR TITLE
SKY-802 Fetch total number of uploads & storage used

### DIFF
--- a/src/components/CurrentUsage/CurrentUsage.js
+++ b/src/components/CurrentUsage/CurrentUsage.js
@@ -29,9 +29,9 @@ const useUsageData = () => {
 
     if (hasData && !hasError) {
       setUsage({
-        filesUsed: stats?.numUploads,
+        filesUsed: stats?.numUploadsTotal,
         filesLimit: activePlan?.limits?.maxNumberUploads,
-        storageUsed: stats?.totalUploadsSize,
+        storageUsed: stats?.uploadsSizeTotal,
         storageLimit: activePlan?.limits?.storageLimit,
       });
     }


### PR DESCRIPTION
## Overview
Start using the new `*Total` properties of `api/user/stats` endpoints.
This tackles SKY-802, backend was prepared in SKY-794.