### PR TITLE
Support return_to query param on registration flow

### DIFF
--- a/src/components/HighlightedLink.js
+++ b/src/components/HighlightedLink.js
@@ -1,6 +1,43 @@
+import PropTypes from "prop-types";
 import { Link } from "gatsby";
+import { useLocation } from "react-use";
 import styled from "styled-components";
 
-export default styled(Link).attrs({
+const StyledLink = styled(Link).attrs({
   className: "text-primary underline-offset-2 decoration-1 decoration-dotted hover:text-primary-light hover:underline",
 })``;
+
+/**
+ * This an extended version of Gatsby's <Link /> component, which
+ * is also styled to match Skynet Labs' dashboard's theme.
+ */
+export default function HighlightedLink({ persistQueryString, to, ...props }) {
+  const { search, origin } = useLocation();
+  let url = to;
+
+  if (persistQueryString) {
+    const targetUrl = new URL(url, origin); // Use current origin as a base (it will be discarded it `url` is an absolute URL)
+    const currentQueryParams = new URLSearchParams(search);
+    currentQueryParams.forEach((value, key) => {
+      // Do not override query params if they exist already
+      if (!targetUrl.searchParams.has(key)) {
+        targetUrl.searchParams.set(key, value);
+      }
+    });
+
+    url = targetUrl.toString().replace(origin, "");
+  }
+
+  return <StyledLink to={url} {...props} />;
+}
+
+HighlightedLink.propTypes = {
+  /**
+   * If specified, current page's query parameters will be appended
+   * to the `to` parameter this component's instance receives.
+   *
+   * This is useful when we want to persist the redirect URL parameter
+   * across subpage's navigation (i.e. switching between login/sign up pages).
+   */
+  persistQueryString: PropTypes.bool,
+};

--- a/src/components/forms/LoginForm.js
+++ b/src/components/forms/LoginForm.js
@@ -49,7 +49,7 @@ export const LoginForm = ({ onSuccess }) => {
         }
       }}
     >
-      {({ errors, touched }) => (
+      {({ errors, touched, isSubmitting }) => (
         <Form className="flex flex-col gap-4">
           <h3 className="mt-4 mb-4">Log in to your account</h3>
           {error && <p className="px-4 py-3 rounded border border-error bg-red-50 text-error mb-4">{error}</p>}
@@ -76,13 +76,16 @@ export const LoginForm = ({ onSuccess }) => {
           </div>
 
           <div className="flex w-full justify-center mt-4">
-            <Button type="submit" className="px-12" $primary>
-              Log in
+            <Button type="submit" className="px-12" $primary disabled={isSubmitting}>
+              {isSubmitting ? "Logging in..." : "Log in"}
             </Button>
           </div>
 
           <p className="text-sm text-center mt-8">
-            Don't have an account? <HighlightedLink to="/auth/registration">Sign up</HighlightedLink>
+            Don't have an account?{" "}
+            <HighlightedLink to="/auth/registration" persistQueryString>
+              Sign up
+            </HighlightedLink>
           </p>
         </Form>
       )}

--- a/src/components/forms/SignUpForm.js
+++ b/src/components/forms/SignUpForm.js
@@ -61,7 +61,7 @@ export const SignUpForm = ({ onSuccess, onFailure }) => (
       }
     }}
   >
-    {({ errors, touched }) => (
+    {({ errors, touched, isSubmitting }) => (
       <Form className="flex flex-col gap-4">
         <TextField
           type="text"
@@ -91,8 +91,8 @@ export const SignUpForm = ({ onSuccess, onFailure }) => (
         />
 
         <div className="flex w-full justify-center mt-4">
-          <Button type="submit" className="px-12" $primary>
-            Sign up!
+          <Button type="submit" className="px-12" $primary disabled={isSubmitting}>
+            {isSubmitting ? "Signing up..." : "Sign up!"}
           </Button>
         </div>
       </Form>

--- a/src/hooks/useRedirectParam.js
+++ b/src/hooks/useRedirectParam.js
@@ -1,0 +1,10 @@
+export default function useRedirectParam(location) {
+  const query = new URLSearchParams(location.search);
+  const redirectTarget = query.get("return_to");
+
+  return {
+    // Convert absolute, internal URLs into paths
+    url: redirectTarget ? redirectTarget.replace(location.origin, "") : null,
+    internal: redirectTarget ? redirectTarget.includes(location.origin) : false,
+  };
+}

--- a/src/pages/auth/login.js
+++ b/src/pages/auth/login.js
@@ -3,29 +3,20 @@ import AuthLayout from "../../layouts/AuthLayout";
 import { LoginForm } from "../../components/forms";
 import { useUser } from "../../contexts/user";
 import { Metadata } from "../../components/Metadata";
-
-const isUrl = (url) => {
-  try {
-    new URL(url); // try to parse it, throws on invalid url
-  } catch {
-    return false;
-  }
-  return true;
-};
+import useRedirectParam from "../../hooks/useRedirectParam";
 
 const LoginPage = ({ location }) => {
   const { mutate: refreshUserState } = useUser();
-  const onSuccess = async () => {
-    const query = new URLSearchParams(location.search);
-    const redirectTo = query.get("return_to") || "/";
+  const { url, internal } = useRedirectParam(location);
 
+  const onSuccess = async () => {
     // for internal redirect, wait for user state to be refreshed to avoid
     // authenticated user state being used before user state is refreshed
-    if (!isUrl(redirectTo)) {
+    if (!url || internal) {
       await refreshUserState();
     }
 
-    navigate(redirectTo);
+    navigate(url || "/");
   };
 
   return (


### PR DESCRIPTION
## Overview
* Extend <HighlightedLink /> to allow persisting current query parameters
* Fix return_to query param being dropped switching to registration form
* Add 'loading' state to login & signup forms


## Visuals

### Internal redirect - sign up & login flows
https://user-images.githubusercontent.com/3853033/173794975-5588c42a-7ef4-458c-9020-e3e84577fa8c.mov

### External redirect (e.g. a skylink) - sign up & login flows
https://user-images.githubusercontent.com/3853033/173795038-a600755a-aea0-4150-a47f-39ffd61dd3f4.mov