### PR TITLE
Use plugin to access environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This file allows to easily control which domain name you want to use locally and
 Example:
 
 ```env
-GATSBY_PORTAL_DOMAIN=skynetfree.net # Use skynetfree.net APIs
+PORTAL_DOMAIN=skynetfree.net # Use skynetfree.net APIs
 GATSBY_HOST=local.skynetfree.net # Address of your local build
+STRIPE_PUBLISHABLE_KEY=asdf_1234
 ```
 
 > It's recommended to keep the 2LD the same, so any cookies dispatched by the API work without issues.

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -14,7 +14,7 @@ import swrConfig from "./src/lib/swrConfig";
 import { MODAL_ROOT_ID } from "./src/components/Modal";
 import { PortalSettingsProvider } from "./src/contexts/portal-settings";
 
-const stripePromise = loadStripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY);
+const stripePromise = loadStripe(process.env.STRIPE_PUBLISHABLE_KEY);
 
 export function wrapPageElement({ element, props }) {
   const Layout = element.type.Layout ?? React.Fragment;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,12 +4,12 @@ require("dotenv").config({
 
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
-const { GATSBY_PORTAL_DOMAIN } = process.env;
+const { PORTAL_DOMAIN } = process.env;
 
 module.exports = {
   siteMetadata: {
     title: `Account Dashboard`,
-    siteUrl: `https://account.${GATSBY_PORTAL_DOMAIN}`,
+    siteUrl: `https://account.${PORTAL_DOMAIN}`,
   },
   trailingSlash: "never",
   plugins: [
@@ -28,13 +28,19 @@ module.exports = {
       },
       __key: "images",
     },
+    {
+      resolve: `gatsby-plugin-env-variables`,
+      options: {
+        allowList: ["PORTAL_DOMAIN", "STRIPE_PUBLISHABLE_KEY"],
+      },
+    },
   ],
   developMiddleware: (app) => {
     // Proxy Accounts service API requests:
     app.use(
       "/api/",
       createProxyMiddleware({
-        target: `https://account.${GATSBY_PORTAL_DOMAIN}`,
+        target: `https://account.${PORTAL_DOMAIN}`,
         secure: false, // Do not reject self-signed certificates.
         changeOrigin: true,
       })
@@ -44,7 +50,7 @@ module.exports = {
     app.use(
       ["/skynet", "/__internal/"],
       createProxyMiddleware({
-        target: `https://${GATSBY_PORTAL_DOMAIN}`,
+        target: `https://${PORTAL_DOMAIN}`,
         secure: false, // Do not reject self-signed certificates.
         changeOrigin: true,
         pathRewrite: {

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -14,7 +14,7 @@ import swrConfig from "./src/lib/swrConfig";
 import { MODAL_ROOT_ID } from "./src/components/Modal";
 import { PortalSettingsProvider } from "./src/contexts/portal-settings";
 
-const stripePromise = loadStripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY);
+const stripePromise = loadStripe(process.env.STRIPE_PUBLISHABLE_KEY);
 
 export function wrapPageElement({ element, props }) {
   const Layout = element.type.Layout ?? React.Fragment;

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-config-react-app": "^7.0.0",
     "eslint-plugin-storybook": "^0.5.6",
     "gatsby-plugin-alias-imports": "^1.0.5",
+    "gatsby-plugin-env-variables": "^2.2.0",
     "gatsby-plugin-image": "^2.6.0",
     "gatsby-plugin-preval": "^1.0.0",
     "gatsby-plugin-provide-react": "^1.0.2",

--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -35,7 +35,7 @@ export const Metadata = ({ children }) => {
       <meta name="msapplication-TileImage" content={msTileIcon} />
 
       <meta name="description" content="Manage your Skynet uploads, account subscription, settings and API keys" />
-      <link rel="preconnect" href={`https://${process.env.GATSBY_PORTAL_DOMAIN}/`} />
+      <link rel="preconnect" href={`https://${process.env.PORTAL_DOMAIN}/`} />
       {children}
     </Helmet>
   );

--- a/src/contexts/portal-settings/PortalSettingsContext.js
+++ b/src/contexts/portal-settings/PortalSettingsContext.js
@@ -1,9 +1,9 @@
 import { createContext } from "react";
 
-const { GATSBY_PORTAL_DOMAIN } = process.env;
+const { PORTAL_DOMAIN } = process.env;
 
 export const defaultSettings = {
-  supportEmail: GATSBY_PORTAL_DOMAIN ? `hello@${GATSBY_PORTAL_DOMAIN}` : null,
+  supportEmail: PORTAL_DOMAIN ? `hello@${PORTAL_DOMAIN}` : null,
   areAccountsEnabled: false,
   isAuthenticationRequired: false,
   isSubscriptionRequired: false,

--- a/src/services/skynetClient.js
+++ b/src/services/skynetClient.js
@@ -1,3 +1,3 @@
 import { SkynetClient } from "skynet-js";
 
-export default new SkynetClient(`https://${process.env.GATSBY_PORTAL_DOMAIN}`);
+export default new SkynetClient(`https://${process.env.PORTAL_DOMAIN}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9304,6 +9304,11 @@ gatsby-plugin-alias-imports@^1.0.5:
   dependencies:
     "@babel/runtime" "^7.2.0"
 
+gatsby-plugin-env-variables@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-2.2.0.tgz#75793854688be8773cdc3a1e1b10f04b1836bbe6"
+  integrity sha512-znnUNqNmGE4qIq+nTaQeiTz54PQw3QRPflWWWtQg5V9ke3QcamEDVbJ1S1a2Afl5pXO7qCiXNaMMb8NFnNHdLw==
+
 gatsby-plugin-image@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-2.7.0.tgz#cec35a39e73cee991a1fa3d66e3584d937bd640b"


### PR DESCRIPTION
## Overview
* Installs `gatsby-plugin-env-variables` plugin so we don't need to worry about proxying webportal's env variables with `GATSBY_` prefix to make them available for Gatsby app.
* Related PR: https://github.com/SkynetLabs/skynet-webportal/pull/2163 - I'll make that PR ready for review once this is merged & released (skynet-webportal would break without these changes being in the image).

✅ Tested on dev3.