### PR TITLE
Do not require stripe if subscription is not required

### DIFF
--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { screen } from "../../lib/cssHelpers";
 import { useUser } from "../../contexts/user";
+import { usePlans } from "../../contexts/plans";
 import { DropdownMenu, DropdownMenuLink } from "../DropdownMenu";
 import { CogIcon, LockClosedIcon, SkynetLogoIcon } from "../Icons";
 import { PageContainer } from "../PageContainer";
@@ -52,6 +53,7 @@ const NavBarBody = styled.nav.attrs({
 
 export const NavBar = () => {
   const { mutate: setUserState } = useUser();
+  const { plans } = usePlans();
 
   const onLogout = async () => {
     try {
@@ -79,9 +81,11 @@ export const NavBar = () => {
             <NavBarLink to="/files" as={Link} activeClassName="!border-b-primary">
               Files
             </NavBarLink>
-            <NavBarLink to="/payments" as={Link} activeClassName="!border-b-primary">
-              Payments
-            </NavBarLink>
+            {plans.some(({ price }) => price > 0) && (
+              <NavBarLink to="/payments" as={Link} activeClassName="!border-b-primary">
+                Payments
+              </NavBarLink>
+            )}
           </NavBarSection>
           <NavBarSection className="dropdown-area justify-end">
             <DropdownMenu title="My account">

--- a/src/layouts/DashboardLayout.js
+++ b/src/layouts/DashboardLayout.js
@@ -5,6 +5,7 @@ import { PageContainer } from "../components/PageContainer";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
 import { UserProvider, useUser } from "../contexts/user";
+import { PlansProvider } from "../contexts/plans/PlansProvider";
 import { FullScreenLoadingIndicator } from "../components/LoadingIndicator";
 
 import dashboardBg from "../../static/images/dashboard-bg.svg";
@@ -30,15 +31,15 @@ const Layout = ({ children }) => {
 };
 
 const DashboardLayout = ({ children }) => (
-  <>
-    <UserProvider>
+  <UserProvider>
+    <PlansProvider>
       <Layout>
         <NavBar />
         <PageContainer className="mt-2 md:mt-14">{children}</PageContainer>
         <Footer />
       </Layout>
-    </UserProvider>
-  </>
+    </PlansProvider>
+  </UserProvider>
 );
 
 export default DashboardLayout;


### PR DESCRIPTION
When Stripe is not configured but portal does not require subscriptions, we should fall back to using only anonymous plan instead of reporting issues on the dashboard.

### Before
![Screenshot 2022-09-12 at 15 19 07](https://user-images.githubusercontent.com/3755029/189665035-f77fd8ab-d662-42a5-be61-4acb331f1477.png)

### After
![Screenshot 2022-09-12 at 15 19 37](https://user-images.githubusercontent.com/3755029/189665049-af0c3ebc-3889-42f0-882d-33a684e63571.png)
